### PR TITLE
Use dashes in configuration filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/sg_mqtt_client.conf
+/sg-mqtt-client.conf
 /target

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enable the [community feed].
 
 The minimal required configuration can be created as follows:
 ```
-cat << EOF > /etc/sg_mqtt_client.conf
+cat << EOF > /etc/sg-mqtt-client.conf
 [mqtt_broker]
 host = my-mqtt-broker.lan
 EOF

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
-const CONFIG_PATH: &str = "/etc/sg_mqtt_client.conf";
+const CONFIG_PATH: &str = "/etc/sg-mqtt-client.conf";
 const LEMONBEATD_COMMAND_URI: &str = "ipc:///tmp/lemonbeatd-command.ipc";
 const LEMONBEATD_EVENT_URI: &str = "ipc:///tmp/lemonbeatd-event.ipc";
 const LWM2MSERVER_COMMAND_URI: &str = "ipc:///tmp/lwm2mserver-command.ipc";


### PR DESCRIPTION
Totally a personal preference, but my system agrees with me:

```shell
$ ls -1d /etc/*-* | wc -l
43
$ ls -1d /etc/*_* | wc -l
12
```